### PR TITLE
fix: wire up accessibilityLabel + add titleFontFamily to ChromeSchema

### DIFF
--- a/src/core/__tests__/config.test.ts
+++ b/src/core/__tests__/config.test.ts
@@ -109,6 +109,14 @@ describe('mergeConfig', () => {
     expect(config.chrome.buttonRadius).toBe(6); // default preserved
   });
 
+  it('accepts chrome.titleFontFamily', () => {
+    const config = mergeConfig({
+      ...minimal,
+      chrome: { titleFontFamily: 'system-ui, sans-serif' },
+    });
+    expect(config.chrome.titleFontFamily).toBe('system-ui, sans-serif');
+  });
+
   it('defaults window style to macos', () => {
     const config = mergeConfig(minimal);
     expect(config.window.style).toBe('macos');

--- a/src/core/__tests__/svg-generator.test.ts
+++ b/src/core/__tests__/svg-generator.test.ts
@@ -31,6 +31,20 @@ describe('generateSvg', () => {
     expect(svg).toContain('echo hello');
   });
 
+  it('honors user-supplied accessibilityLabel when set', () => {
+    const config = makeConfig({ accessibilityLabel: 'Persona-first label' });
+    const svg = generateSvg(basicSequences, config);
+    expect(svg).toContain('aria-label="Persona-first label"');
+    expect(svg).not.toContain('aria-label="Animated terminal showing');
+  });
+
+  it('honors user-supplied accessibilityLabel on static SVG too', () => {
+    const config = makeConfig({ accessibilityLabel: 'Persona-first label' });
+    const svg = generateStaticSvg(['line 1', 'line 2'], config);
+    expect(svg).toContain('aria-label="Persona-first label"');
+    expect(svg).not.toContain('Static terminal showing');
+  });
+
   it('renders shadow filter when effects.shadow is true', () => {
     const svg = generateSvg(basicSequences, makeConfig());
     expect(svg).toContain('filter="url(#shadow)"');

--- a/src/core/config.ts
+++ b/src/core/config.ts
@@ -147,5 +147,8 @@ export function mergeConfig(userConfig: UserConfig): TerminalConfig {
     fetchTimeout: userConfig.fetchTimeout ?? DEFAULT_CONFIG.fetchTimeout,
     cacheTTL: userConfig.cacheTTL ?? DEFAULT_CONFIG.cacheTTL,
     cachePath: userConfig.cachePath ?? DEFAULT_CONFIG.cachePath,
+    ...(userConfig.accessibilityLabel !== undefined
+      ? { accessibilityLabel: userConfig.accessibilityLabel }
+      : {}),
   };
 }

--- a/src/core/schema.ts
+++ b/src/core/schema.ts
@@ -59,6 +59,7 @@ const AccessibilitySchema = z.object({
 }).optional();
 
 const ChromeSchema = z.object({
+  titleFontFamily: z.string().min(1).optional(),
   titleFontSize: z.number().positive('titleFontSize must be positive').optional(),
   buttonRadius: z.number().min(0).optional(),
   buttonSpacing: z.number().positive().optional(),

--- a/src/core/svg-generator.ts
+++ b/src/core/svg-generator.ts
@@ -79,8 +79,8 @@ export function generateSvg(sequences: Sequence[], config: TerminalConfig): stri
     console.warn(`[svg-terminal] Animation duration (${(totalDuration / 1000).toFixed(1)}s) exceeds maxDuration (${config.maxDuration}s)`);
   }
 
-  // Build accessibility label from block commands
-  const accessibilityLabel = buildAccessibilityLabel(sequences);
+  // Honor user-supplied label; fall back to a command-summary built from sequences.
+  const accessibilityLabel = config.accessibilityLabel ?? buildAccessibilityLabel(sequences);
   const showShadow = effects.shadow && window.style !== 'none';
   const a11yChildren = renderAccessibilityChildren(accessibilityLabel, sequences, terminal.prompt, config.accessibility);
 
@@ -529,7 +529,7 @@ export function generateStaticSvg(lines: string[], config: TerminalConfig): stri
   const titleBarHeight = getTitleBarHeight(window);
   const contentY = titleBarHeight + terminal.paddingTop;
   const viewportHeight = window.height - titleBarHeight;
-  const accessibilityLabel = `Static terminal showing ${lines.length} lines`;
+  const accessibilityLabel = config.accessibilityLabel ?? `Static terminal showing ${lines.length} lines`;
   const a11yChildren = renderStaticAccessibilityChildren(accessibilityLabel, lines, config.accessibility);
   const colorMap = buildColorMap(theme.colors);
   const glow = effects.textGlow ? ' filter="url(#textGlow)"' : '';

--- a/src/types.ts
+++ b/src/types.ts
@@ -199,6 +199,8 @@ export interface TerminalConfig {
   cacheTTL: number;
   /** Cache file path, relative to the config file (default: `.svg-terminal-cache.json`) */
   cachePath: string;
+  /** Custom aria-label for the root SVG. Overrides the auto-generated command summary. */
+  accessibilityLabel?: string;
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

Two related schema-vs-generator drift bugs (#97 + #98):

- **`config.accessibilityLabel` was silently ignored.** Declared in `UserConfig` + `UserConfigSchema`, but `mergeConfig` never propagated it and `svg-generator` never read it. Result: setting the key in YAML did nothing — even under `--strict`, which was misleading because `--strict` validates the key exists.
- **`chrome.titleFontFamily` was on the TS interface but missing from the zod schema.** Documented in the README, accepted by the type, rejected by `--strict`.

Both surfaced as I was updating my profile README (`williamzujkowski/williamzujkowski`).

## Changes

- `src/core/svg-generator.ts` — read `config.accessibilityLabel ?? auto` in both `generateSvg` and `generateStaticSvg`. One-line each.
- `src/types.ts` — add `accessibilityLabel?: string` to `TerminalConfig` so the generator can read it post-merge.
- `src/core/config.ts` — propagate `accessibilityLabel` through `mergeConfig` (conditional spread so it doesn't pollute when unset).
- `src/core/schema.ts` — add `titleFontFamily: z.string().min(1).optional()` to `ChromeSchema`.
- Tests — 3 new (animated label override, static label override, `titleFontFamily` round-trip). 279/279 pass.

## Verification

\`\`\`bash
$ npm run typecheck   # clean
$ npm test            # 279 passed
$ npm run lint        # clean
\`\`\`

## Closes

- Closes #97
- Closes #98